### PR TITLE
feat: complete da-DK translation

### DIFF
--- a/locale/da-DK/brightness.entity
+++ b/locale/da-DK/brightness.entity
@@ -1,0 +1,13 @@
+#
+##
+###
+#%
+##%
+###%
+fuld
+lys
+halv
+dæmpet
+lav
+auto
+automatisk

--- a/locale/da-DK/brightness.intent
+++ b/locale/da-DK/brightness.intent
@@ -1,11 +1,12 @@
-(skift|indstil|omskifter) (det|dit) (øje|) (lysstyrke|belysning) (niveau|) til {lysstyrke} (procent|)
-(skift|indstil|omskifter) (din|din) (øje|) (lysstyrke|belysning) (niveau|)
+(skift|indstil|omskifter) (dit|dit) (øje|) (lysstyrke|belysning) (niveau|) til {brightness} (procent|)
+(skift|indstil|omskifter) (dit|dit) (øje|) (lysstyrke|belysning) (niveau|)
 (skift|indstil|skift) til {brightness} (procent|) (øje|) (lysstyrke|belysning)
 drej (den|) (lysstyrke|belysning) (ned|op) til {brightness} (procent|)
-du er (også|) (lys|dæmpet)
+skru (den|) (lysstyrke|belysning) (ned|op) til {brightness} (procent|)
+du er (for|) (lys|dæmpet)
 dæmp (dine) øjne til {brightness} (procent|)
 dæmpe det lidt ned
-dæmpe ned til {lysstyrke} (procent|)
+dæmpe ned til {brightness} (procent|)
 lysne det op
 lysne op (en smule|) til {brightness} (procent|)
 skru (ned|op) (den|) (lysstyrke|belysning) til {brightness} (procent|)

--- a/locale/da-DK/color.entity
+++ b/locale/da-DK/color.entity
@@ -1,0 +1,160 @@
+standard
+alice blå
+aliceblå
+antik hvid
+aqua
+aquamarin
+azurblå
+beige
+bisque
+sort
+blancheret mandel
+blå
+blåviolet
+brun
+træ farve
+træfarve
+kadetblå
+chartreuse
+chokolade
+koral
+kornblomstblå
+korn blomst blå
+majssilke
+majs silke
+karmoisinrød
+cyan
+mørkeblå
+mørk cyan
+mørk gyldenris
+mørkgyldenris
+mørkegrå
+mørkegrå
+mørkegrøn
+mørk khaki
+mørk magenta
+mørk olivengrøn
+mørk orange
+mørk orkidé
+mørkerød
+mørk laks
+mørk havgrøn
+mørk skiferblå
+mørk skifergrå
+mørk skifergrå
+mørk turkis
+mørk violet
+dyb pink
+dyb himmelblå
+sløret grå
+sløret grå
+dodgerblå
+mursten
+mursten
+blomsterhvid
+skovgrøn
+fuchsia
+fuchsia
+gainsboro
+spøgelseshvid
+guld
+gyldenris
+grå
+grå
+grøn
+grøngul
+honningdug
+honningdug
+knaldpink
+indisk rød
+indigo
+elfenben
+khaki
+lavendel
+lavendelrødme
+plænegrøn
+citronchiffon
+lyseblå
+lys koral
+lys cyan
+lys gyldenrisgul
+lys gyldenrisgul
+lysegrå
+lysegrå
+lysegrøn
+lyserosa
+lys laks
+lys havgrøn
+lys himmelblå
+lys skifergrå
+lys skifergrå
+lys stålblå
+lysegul
+lime
+limegrøn
+lærred
+magenta
+rødbrun
+mellem aquamarin
+mellemblå
+mellem orkidé
+mellemlilla
+mellem havgrøn
+mellem skiferblå
+mellem forårsgrøn
+mellem turkis
+mellem violetrød
+midnatsblå
+mintcreme
+tåget rosa
+mokkasin
+navajohvid
+marineblå
+gammel blonde
+oliven
+matoliven
+orange
+orangerød
+orkidé
+bleg gyldenris
+bleg gyldenris
+bleggrøn
+bleg turkis
+bleg violetrød
+papaya
+fersken
+peru
+pink
+blomme
+pudderblå
+lilla
+rebecca-lilla
+rød
+rosenbrun
+kongeblå
+saddelbrun
+laks
+sandbrun
+havgrøn
+havskal
+havskal
+sienna
+sølv
+himmelblå
+skiferblå
+skifergrå
+skifergrå
+sne
+forårsgrøn
+stålblå
+solbrun
+petroleumsblå
+tidsel
+tomat
+turkis
+violet
+hvede
+hvid
+hviderøg
+gul
+gulgrøn


### PR DESCRIPTION
Adds the two files that were missing from the existing da-DK translation (present in every other locale): brightness.entity and color.entity (the CSS3 extended color-name list, 160 entries).

Also fixes brightness.intent:
- adds the one missing template line (en-US has 13, da-DK had 12)
- fixes two lines that referenced a non-existent {lysstyrke} slot instead of the {brightness} slot the skill code actually expects - these patterns would never have matched anything
- fixes a mistranslation ("også"/also instead of "for"/too) in the "you are too bright/dim" pattern