### PR TITLE
docs: rewrite README in Simplified Technical English

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,24 @@
 ## Mark1 Enclosure Control
 
-Controls the enclosure api vocally
+An OVOS skill that controls the Mycroft Mark 1 enclosure by voice.
 
 ## Description
 
-The Mycroft Mark 1 has several unique capabilities which this Skill lets you control.
+The Mycroft Mark 1 has a matrix of eyes that can change color and play
+animations. This skill lets you control those eyes and other enclosure
+features by voice, including eye color, brightness, and eye movement
+animations.
 
-The Mark 1 has beautiful eyes -- and you get to pick their color!  Set them to
-a named color ("blue", "magenta", "teal", etc) or any color using RGB values.
-Please see the [ovos-color-parser](https://github.com/OpenVoiceOS/ovos-color-parser)
-for more options
+Set the eye color to a named color ("blue", "magenta", "teal", and others)
+or to a custom RGB value. See
+[ovos-color-parser](https://github.com/OpenVoiceOS/ovos-color-parser) for
+the full list of supported colors and formats.
 
+## Install
+
+```bash
+pip install ovos-skill-mark1-ctrl
+```
 
 ## Examples
 
@@ -20,20 +28,31 @@ for more options
 * "look up"
 * "look down"
 * "look left"
+
 * "look right"
 * "look left and right"
 * "look up and down"
 * "reset enclosure"
+
 * "narrow your eyes"
 * "spin your eyes"
 * "blink your eyes"
+
 * "smile animation"
 * "listen animation"
 * "think animation"
 
+## Related projects
+
+* [ovos-color-parser](https://github.com/OpenVoiceOS/ovos-color-parser): parses the color names and values this skill accepts
+* [ovos-i2c-detection](https://github.com/OpenVoiceOS/ovos-i2c-detection): detects the Mark 1 enclosure hardware this skill controls
+
+## License
+
+Apache-2.0
 
 ## Credits
 
 JarbasAI
 
-MycroftAI - https://github.com/MycroftAI/mycroft-mark-1
+[MycroftAI](https://github.com/MycroftAI/mycroft-mark-1)


### PR DESCRIPTION
Rewrites the README for clarity: adds an install section, a related-projects section linking ovos-color-parser and ovos-i2c-detection, and a license section, while keeping every existing fact and example intact.

Rewritten by Claude Sonnet 5 using the ste-writing skill (authored and reviewed by Claude Fable 5); linted with ste_lint.py.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added instructions for voice-controlling the Mark 1 enclosure, including eye colors, brightness, movement, animations, and custom RGB values.
  * Documented installation via pip and expanded usage examples.
  * Added Related Projects and License sections.
  * Updated the MycroftAI credit with a direct link.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->