### PR TITLE
fix: replace fixed sleep with bounded polling in end2end tests

### DIFF
--- a/test/end2end/test_intents_en_us.py
+++ b/test/end2end/test_intents_en_us.py
@@ -69,7 +69,12 @@ class _RoutingTest(TestCase):
                 {"utterances": [utterance], "lang": LANG},
                 {"session": session.serialize()},
             ))
-            time.sleep(3)
+            # Under CI load routing can take longer than a fixed sleep would
+            # allow, so poll for the routed message up to a bounded deadline
+            # instead of sleeping a fixed amount.
+            deadline = time.monotonic() + 15
+            while not routed and time.monotonic() < deadline:
+                time.sleep(0.5)
         finally:
             self.bus.remove(topic, cb)
         return routed


### PR DESCRIPTION
> 🤖 Auto-generated by Claude Fable 5 (claude-fable-5) via Claude Code — NOT human-reviewed. Verify before acting.

This fixes a pre-existing flaky test. `test/end2end/test_intents_en_us.py::test_set_eye_brightness_to_50` used a fixed three-second sleep after sending the utterance, then checked the routed message. On CI it failed twice when routing took a bit longer than three seconds.

The fix replaces that fixed sleep with a bounded poll — up to 15 seconds, checking every half second — that returns as soon as the expected message shows up, using the same pattern already in `ovos-skill-date-time`'s end2end tests. It was the only fixed sleep in the file, and both `test_set_the_eye_color_to_red` and `test_set_eye_brightness_to_50` go through the shared helper that had it, so both tests get the fix.

Verified locally in a throwaway venv: both tests pass.
